### PR TITLE
Add missing colon to bucket arn

### DIFF
--- a/SNStopicPolicy.json
+++ b/SNStopicPolicy.json
@@ -19,7 +19,7 @@
 				"SNS:Publish",			
 				"SNS:Receive"
 			],
-			"Resource": "arn:aws:sns:*:catguru",
+			"Resource": "arn:aws:sns:*:*:catguru",
 			"Condition": {
 				"ArnLike": {
 					"aws:SourceArn": "arn:aws:s3:::catgurublog"

--- a/SNStopicPolicy.json
+++ b/SNStopicPolicy.json
@@ -22,7 +22,7 @@
 			"Resource": "arn:aws:sns:*:catguru",
 			"Condition": {
 				"ArnLike": {
-					"aws:SourceArn": "arn:aws:s3:*:catgurublog"
+					"aws:SourceArn": "arn:aws:s3:::catgurublog"
 				}
 			}
 		}


### PR DESCRIPTION
The bucket arn is missing a colon, which results in this error when trying to create the event:

Unable to validate the following destination configurations. Permissions on the destination topic do not allow S3 to publish notifications from this bucket. (arn:aws:sns:eu-west-1:xxxxxxxxxxx:catguru)

Interesting problem to have to solve as a beginner :) Had to look at the individual lines and what they do in the policy before I homed in on the cause.